### PR TITLE
Make return type of `Images::prune` optional

### DIFF
--- a/src/api/images.rs
+++ b/src/api/images.rs
@@ -582,7 +582,7 @@ impl<'podman> Images<'podman> {
     pub async fn prune(
         &self,
         opts: &opts::ImagePruneOpts,
-    ) -> Result<Vec<models::PruneReport>> {
+    ) -> Result<Option<Vec<models::PruneReport>>> {
         let ep = url::construct_ep("/libpod/images/prune", opts.serialize());
         self.podman.post_json(&ep, Payload::empty()).await
     }}


### PR DESCRIPTION
## Commit message
If there are no images to prune, Podman just returns `null` instead of
an empty list.
```
  ❯ podman pull alpine
  Resolved "alpine" as an alias (/etc/containers/registries.conf.d/000-…
  Trying to pull docker.io/library/alpine:latest...
  Getting image source signatures
  Copying blob 40e059520d19 done
  Copying config 76c8fb57b6 done
  Writing manifest to image destination
  Storing signatures
  76c8fb57b6fc8599de38027112c47170bd19f99e7945392bd78d6816db01f4ad
  ❯ curl -X POST --unix-socket /run/user/1000/podman/podman.sock \
    http://d/v3.0.0/libpod/images/prune\?all\=true
  [{"Id":"76c8fb57b6fc8599de38027112c47170bd19f99e7945392bd78d6816db01f…
  ❯ curl -X POST --unix-socket /run/user/1000/podman/podman.sock \
    http://d/v3.0.0/libpod/images/prune\?all\=true
  null
```
## What did you implement:
It's a fix for a crash that is caused by a deserialization error in `Images::prune`. Crash happens if no images are to be pruned.

## How did you verify your change:
I tested with `curl` as described in the commit message.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
There is already a message in the changelog about fixing the `Images::prune` return type.