### PR TITLE
Add `portmappings` to `ContainerCreateOptsBuilder `

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -16,6 +16,20 @@ macro_rules! impl_vec_field {
             }
         }
     };
+    ($(#[doc = $docs:expr])* $name:ident: $ty:ty => $api_name:literal) => {
+        paste::item! {
+            $(
+                #[doc= $docs]
+            )*
+            pub fn [< $name  >]<I>(mut self, $name: I)-> Self
+            where
+                I: IntoIterator<Item = $ty>,
+            {
+                self.params.insert($api_name, serde_json::json!($name.into_iter().collect::<Vec<_>>()));
+                self
+            }
+        }
+    };
 }
 
 macro_rules! impl_field {

--- a/src/opts/containers.rs
+++ b/src/opts/containers.rs
@@ -622,7 +622,11 @@ impl ContainerCreateOptsBuilder {
         pod => "pod"
     );
 
-    // TODO: portmappings
+    impl_vec_field!(
+        /// Set of ports to map into the container. Only available if NetNS is set to bridge or
+        /// slirp.
+        portmappings: models::PortMapping => "portmappings"
+    );
 
     impl_field!(
         /// Whether the container is privileged. Privileged does the following: Adds all devices on


### PR DESCRIPTION
## What did you implement:

While working on this [PR](https://github.com/marhkb/pods/tree/create-container) I saw that there is a TODO for `portmappings` in `ContainerCreateOptsBuilder`, which I need. Thus, I implemented it.

## How did you verify your change
I tested this within the [PR](https://github.com/marhkb/pods/tree/create-container).

![Bildschirmfoto von 2022-04-14 23-18-19](https://user-images.githubusercontent.com/3630213/163478058-e90ae769-bd70-4dbd-acf0-88992a860a9c.png)

The code I use is basically:

```rust
//...
.portmappings(
    imp.port_mappings
        .borrow()
        .to_owned()
        .to_typed_list_model::<model::PortMapping>()
        .into_iter()
        .map(|port_mapping| api::PortMapping {
            container_port: Some(port_mapping.container_port() as i64),
            host_ip: None,
            host_port: Some(port_mapping.host_port() as i64),
            protocol: Some(port_mapping.protocol().to_string()),
            range: None,
        }),
)
//...
```

The portmappings are accepted and are shown in cockpit.

![Bildschirmfoto von 2022-04-14 23-18-31](https://user-images.githubusercontent.com/3630213/163478222-03f43aee-5c52-468b-81fd-18083cba5a22.png)


## What (if anything) would need to be called out in the CHANGELOG for the next release

Probably the titles of both commits would fit here.