### PR TITLE
Fix typo `referene` in `PullOptsBuilder`

### DIFF
--- a/src/opts/images.rs
+++ b/src/opts/images.rs
@@ -498,7 +498,7 @@ impl PullOptsBuilder {
 
     impl_url_str_field!(
         /// Mandatory reference to the image.
-        reference => "referene"
+        reference => "reference"
     );
 
     impl_url_bool_field!(


### PR DESCRIPTION
This should be named `reference`.

## What did you implement:
A fix for a typo

## How did you verify your change:
I couldn't pull images before. Now I can. 

## What (if anything) would need to be called out in the CHANGELOG for the next release:
The commit message subject line may fit well. 