### PR TITLE
Use correct endpoint in `Pods::create`

### DIFF
--- a/src/api/pods.rs
+++ b/src/api/pods.rs
@@ -488,7 +488,7 @@ impl Pods {
 
     api_doc! {
     Pod => CreateLibpod
-    /// Create a container with specified options.
+    /// Create a pod with specified options.
     ///
     /// Examples:
     ///
@@ -512,7 +512,7 @@ impl Pods {
     pub async fn create(&self, opts: &opts::PodCreateOpts) -> Result<Pod> {
         self.podman
             .post_json(
-                &"/libpod/containers/create",
+                &"/libpod/pods/create",
                 Payload::Json(opts.serialize()?),
             )
             .await


### PR DESCRIPTION
The endpoint for creating new containers was used here by mistake. This
commit uses the correct endpoint.

## What did you implement:
A fix for a wrong API endpoint usage.

## How did you verify your change:
I tested it by creating a new pod with a specific name. Before, it did not work, because it wanted to create a container.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
Use correct endpoint in `Pods::create`.