### PR TITLE
Make "Dockerfile" lower case

### DIFF
--- a/src/opts/images.rs
+++ b/src/opts/images.rs
@@ -134,7 +134,7 @@ impl ImageBuildOptsBuilder {
     impl_url_str_field!(
         /// Path within the build context to the Dockerfile. This is ignored
         /// if remote is specified and points to an external Dockerfile.
-        dockerfile => "Dockerfile"
+        dockerfile => "dockerfile"
     );
 
     impl_url_str_field!(


### PR DESCRIPTION
Otherwise, we get a `error 400 Bad Request`.

## What did you implement:
A small fix.

## How did you verify your change:
I tested locally.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
Fixed a typo that prevented the specification of a dockerfile when building an image.