### PR TITLE
Fix `ContainerCreateOptsBuilder::mounts`

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -182,3 +182,25 @@ impl AsRef<str> for PodStatus {
         }
     }
 }
+
+#[derive(Clone, Debug, Serialize)]
+// Actual type used by ContainerCreate mount parameter.
+//
+// See: https://github.com/containers/podman/issues/13717
+pub struct ContainerMount {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destination: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub _type: Option<String>,
+    #[serde(rename = "UIDMappings")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uid_mappings: Option<Vec<IdMap>>,
+    #[serde(rename = "GIDMappings")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gid_mappings: Option<Vec<IdMap>>,
+}

--- a/src/opts/containers.rs
+++ b/src/opts/containers.rs
@@ -695,7 +695,7 @@ impl ContainerCreateOptsBuilder {
         /// [`image_volumes`](ContainerCreateOptsBuilder::image_volumes) and
         /// [`volumes_from`](ContainerCreateOptsBuilder::volumes_from) volumes where there
         /// are conflicts.
-        mounts: models::Mount => "mounts"
+        mounts: models::ContainerMount => "mounts"
     );
 
     impl_str_field!(


### PR DESCRIPTION
This PR introduces a new `ContainerMount` type and changes the type used by `ContainerCreateOptsBuilder::mounts`.

Closes: #138
