### PR TITLE
Use POST inside `Exec::resize`

### DIFF
--- a/src/api/exec.rs
+++ b/src/api/exec.rs
@@ -137,6 +137,6 @@ impl Exec {
                 ("w", width.to_string()),
             ])),
         );
-        self.podman.get_json(&ep).await
+        self.podman.post(&ep, Payload::None::<&str>, Headers::none()).await.map(|_| ())
     }}
 }


### PR DESCRIPTION
Otherwise, the function always returns a serialization error.

## What did you implement:

I was trying to resize an exec instance in https://github.com/marhkb/pods/pull/451 but realized that it always failed because GET was used instead of POST. Therefore, I changed to POST.

## How did you verify your change:

After implementing the change, the width of the output of `ls` in an Alpine container could be changed. 
