### PR TITLE
Exec detach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.10.0
+* *BREAKING* Exec::start now returns `Result<Option<tty::Multiplexer>>` (was `Result<tty::Multiplexer>`) [#155](https://github.com/vv9k/podman-api-rs/pull/155)
+
 # 0.9.0
 * Add `ContainerDeleteOpts::timeout`
 * Change `Exec::start` to async fn returning a tty::Multiplexer (the same as `Container::attach`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.10.0
-* *BREAKING* Exec::start now returns `Result<Option<tty::Multiplexer>>` (was `Result<tty::Multiplexer>`) [#155](https://github.com/vv9k/podman-api-rs/pull/155)
+* *BREAKING* `Exec::start` now returns `Result<Option<tty::Multiplexer>>` (was `Result<tty::Multiplexer>`) [#155](https://github.com/vv9k/podman-api-rs/pull/155)
 
 # 0.9.0
 * Add `ContainerDeleteOpts::timeout`

--- a/src/api/exec.rs
+++ b/src/api/exec.rs
@@ -122,7 +122,7 @@ impl Exec {
                 .map_err(|e| crate::conn::Error::Any(Box::new(e)))?,
         );
 
-        let detach = opts.params.get("Detach").map(|value| value.as_bool().unwrap_or(false)).unwrap_or(false);
+        let detach = opts.params.get("Detach").and_then(|value| value.as_bool()).unwrap_or(false);
 
         if !detach {
             self.podman.post_upgrade_stream(ep, payload).await.map(|x| {

--- a/src/api/exec.rs
+++ b/src/api/exec.rs
@@ -1,8 +1,6 @@
-use bytes::Bytes;
-
 use crate::{
     conn::{tty, Headers, Payload},
-    opts, Error, Result, Value,
+    opts, Result, Value,
 };
 
 use containers_api::url;

--- a/src/api/exec.rs
+++ b/src/api/exec.rs
@@ -133,15 +133,7 @@ impl Exec {
                 }
             })
         } else {
-            let res = self.podman.post(ep, payload, None).await?;
-            if res.status().is_success() {
-                Ok(None)
-            } else {
-                let code = res.status();
-                let body = containers_api::conn::hyper::body::to_bytes(res.into_body()).await.unwrap_or(Bytes::new()).to_vec();
-                let message = String::from_utf8(body).unwrap_or(String::new());
-                Err(Error::Fault { code, message })
-            }
+            self.podman.post(ep, payload, None).await.map(|_| None)
         }
     }}
 

--- a/tests/container_tests.rs
+++ b/tests/container_tests.rs
@@ -439,7 +439,7 @@ async fn container_exec() {
 async fn container_exec_detach() {
     let podman = init_runtime();
 
-    let container_name = "test-exec-container";
+    let container_name = "test-exec-detach-container";
     let container = create_base_container(&podman, container_name, None).await;
 
     let _ = container.start(None).await;

--- a/tests/container_tests.rs
+++ b/tests/container_tests.rs
@@ -7,6 +7,7 @@ use common::{
     opts::{ContainerCreateOpts, ExecCreateOpts},
     StreamExt, TryStreamExt, DEFAULT_CMD, DEFAULT_CMD_ARRAY, DEFAULT_IMAGE,
 };
+use podman_api::opts::ExecStartOpts;
 
 #[tokio::test]
 async fn container_create_exists_remove() {
@@ -387,7 +388,7 @@ async fn container_exec() {
     assert!(exec_result.is_ok());
     let exec = exec_result.unwrap();
     let opts = Default::default();
-    let mut exec_stream = exec.start(&opts).await.unwrap();
+    let mut exec_stream = exec.start(&opts).await.unwrap().unwrap();
     while exec_stream.next().await.is_some() {}
 
     let exec_inspect_result = exec.inspect().await;
@@ -407,7 +408,81 @@ async fn container_exec() {
         .await;
     assert!(exec_result.is_ok());
     let exec = exec_result.unwrap();
-    let mut exec_stream = exec.start(&opts).await.unwrap();
+    let mut exec_stream = exec.start(&opts).await.unwrap().unwrap();
+    let chunk = exec_stream.next().await;
+    assert!(chunk.is_some());
+    match chunk.unwrap() {
+        Ok(TtyChunk::StdOut(chunk)) => {
+            let testfile_content = String::from_utf8_lossy(&chunk);
+            assert_eq!(testfile_content, "1234\n");
+        }
+        Ok(chunk) => {
+            let fd = match chunk {
+                TtyChunk::StdIn(_) => "stdin",
+                TtyChunk::StdOut(_) => "stdOut",
+                TtyChunk::StdErr(_) => "stderr",
+            };
+            let chunk = String::from_utf8_lossy(&chunk);
+            eprintln!("invalid chunk, fd: {fd}, content: `{chunk:?}`");
+            std::process::exit(1);
+        }
+        chunk => {
+            eprintln!("invalid chunk {chunk:?}");
+            std::process::exit(1);
+        }
+    }
+
+    cleanup_container(&podman, container_name).await;
+}
+
+#[tokio::test]
+async fn container_exec_detach() {
+    let podman = init_runtime();
+
+    let container_name = "test-exec-container";
+    let container = create_base_container(&podman, container_name, None).await;
+
+    let _ = container.start(None).await;
+
+    let exec_result = container
+        .create_exec(
+            &ExecCreateOpts::builder()
+                .attach_stdin(false)
+                .attach_stderr(false)
+                .attach_stdout(false)
+                .command([
+                    "bash",
+                    "-c",
+                    "mkdir /tmp/test123 && echo 1234 >> /tmp/test123/testfile",
+                ])
+                .build(),
+        )
+        .await;
+    assert!(exec_result.is_ok());
+    let exec = exec_result.unwrap();
+    let opts = ExecStartOpts::builder().detach(true).build();
+    let exec_stream = exec.start(&opts).await.unwrap();
+    assert!(exec_stream.is_none());
+
+    let exec_inspect_result = exec.inspect().await;
+    assert!(exec_inspect_result.is_ok());
+    let exec_inspect_data = exec_inspect_result.unwrap();
+    assert_eq!(exec_inspect_data.get("ExitCode").unwrap(), 0);
+
+    let exec_result = container
+        .create_exec(
+            &ExecCreateOpts::builder()
+                .attach_stderr(true)
+                .attach_stdout(true)
+                .command(["cat", "test123/testfile"])
+                .working_dir("/tmp")
+                .build(),
+        )
+        .await;
+    assert!(exec_result.is_ok());
+    let exec = exec_result.unwrap();
+    let opts = Default::default();
+    let mut exec_stream = exec.start(&opts).await.unwrap().unwrap();
     let chunk = exec_stream.next().await;
     assert!(chunk.is_some());
     match chunk.unwrap() {
@@ -458,7 +533,7 @@ async fn container_copy_from() {
         .await
         .expect("valid exec instance");
     let opts = Default::default();
-    let mut exec_stream = exec.start(&opts).await.unwrap();
+    let mut exec_stream = exec.start(&opts).await.unwrap().unwrap();
     while exec_stream.next().await.is_some() {}
 
     let tar_stream = container.copy_from("/tmp/test123");
@@ -498,7 +573,7 @@ async fn container_copy_file_into() {
         .await
         .expect("valid exec instance");
     let opts = Default::default();
-    let mut exec_stream = exec.start(&opts).await.unwrap();
+    let mut exec_stream = exec.start(&opts).await.unwrap().unwrap();
     let chunk = exec_stream.next().await;
     assert!(chunk.is_some());
     match chunk.unwrap() {
@@ -539,7 +614,7 @@ async fn container_changes() {
         .expect("valid exec instance");
 
     let opts = Default::default();
-    let mut exec_stream = exec.start(&opts).await.unwrap();
+    let mut exec_stream = exec.start(&opts).await.unwrap().unwrap();
     while exec_stream.next().await.is_some() {}
 
     use podman_api::models::ContainerChangeResponseItem;
@@ -753,7 +828,7 @@ async fn container_healthcheck() {
         .expect("valid exec instance");
 
     let opts = Default::default();
-    let mut exec_stream = exec.start(&opts).await.unwrap();
+    let mut exec_stream = exec.start(&opts).await.unwrap().unwrap();
     while exec_stream.next().await.is_some() {}
 
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;


### PR DESCRIPTION
## What did you implement:
A fix for Exec::start() that expected the connection to be upgraded to TCP stream unconditionally.

## How did you verify your change:
I use it in my project and it passes existing tests and an additional test specifically made to check my change (container_exec_detach).