### PR TITLE
Fix 405 error in `Pods::prune` by using HTTP POST

### DIFF
--- a/src/api/pods.rs
+++ b/src/api/pods.rs
@@ -495,7 +495,7 @@ impl Pods {
     /// };
     /// ```
     pub async fn prune(&self) -> Result<Vec<models::PodPruneReport>> {
-        self.podman.get_json("/libpod/pods/prune").await
+        self.podman.post_json("/libpod/pods/prune", Payload::empty(), Headers::none()).await
     }}
 
     api_doc! {


### PR DESCRIPTION
## What did you implement:

A fix for `Pods::prune`. It was using the wrong HTTP method.

## How did you verify your change:

I did a test run with the new version and got a 200 response.
