### PR TITLE
Fix pushing images when using "destination" param

### DIFF
--- a/src/opts/images.rs
+++ b/src/opts/images.rs
@@ -682,7 +682,7 @@ pub struct ImagePushOptsBuilder {
 impl ImagePushOptsBuilder {
     impl_url_str_field!(
         /// Allows for pushing the image to a different destination than the image refers to.
-        destinations => "destinations"
+        destination => "destination"
     );
 
     impl_url_bool_field!(


### PR DESCRIPTION
## What did you implement:
This commit fixes a bug making it impossible to push an image: The query parameter within the URL that `ImagePushOptsBuilder` builds should actually be named "destination" instead of "destinations".

https://docs.podman.io/en/latest/_static/api.html?version=v4.5#tag/images/operation/ImagePushLibpod

## How did you verify your change:
```rust
image.push(
    &podman::opts::ImagePushOpts::builder()
        .destination(repo_tag)
        .build(),
).await;
```

Before I got:
```
Err(Fault { code: 400, message: "pushing image \"14d08eb6a3451c38471fee12a3515a72d88f7f2eb04bf5d86e511cd00269e1c7\": Invalid image name \"14d08eb6a3451c38471fee12a3515a72d88f7f2eb04bf5d86e511cd00269e1c7\", expected colon-separated transport:reference: Invalid image name \"14d08eb6a3451c38471fee12a3515a72d88f7f2eb04bf5d86e511cd00269e1c7\", expected colon-separated transport:reference" })
```

Applying the fix I get (not authentificated, but works when I login)

```
Err(Fault { code: 400, message: "pushing image \"docker.io/****/****:latest\": writing manifest: uploading manifest latest to docker.io/****/****: requested access to the resource is denied: denied: requested access to the resource is denied" })
```
